### PR TITLE
Update to QT 6.2.2

### DIFF
--- a/creator.cpp
+++ b/creator.cpp
@@ -21,6 +21,7 @@
 #include "ui_creator.h"
 #include "version.h"
 
+#include <QRegularExpression>
 #include <QDebug>
 #include <QString>
 #include <QFile>
@@ -33,7 +34,6 @@
 #include <QThread>
 #include <QTimer>
 #include <QPlainTextEdit>
-#include <QLinkedList>
 #include <QStyleFactory>
 #include <QDesktopServices>
 #include <QMimeData>
@@ -231,7 +231,6 @@ bool Creator::showRootMessageBox()
     msgBox.setText(tr("Root privileges required to write image.\nRun application with sudo."));
     msgBox.setIcon(QMessageBox::Critical);
     msgBox.setStandardButtons(QMessageBox::Ok);
-    msgBox.setButtonText(QMessageBox::Ok, tr("OK"));
     msgBox.exec();
     return true;
 #endif
@@ -566,9 +565,9 @@ void Creator::setProjectImages()
             }
 
             //  LibreELEC-RPi2.arm-7.90.002.img.gz
-            QRegExp regExp = QRegExp(".+-[0-9]+\\.(9[05])\\.[0-9]+.*\\.img\\.gz");
-            regExp.indexIn(imageName);
-            QStringList regExpVal = regExp.capturedTexts();
+            QRegularExpression regExp = QRegularExpression(".+-[0-9]+\\.(9[05])\\.[0-9]+.*\\.img\\.gz");
+            QRegularExpressionMatch match = regExp.match(imageName);
+            QStringList regExpVal = match.capturedTexts();
             QString alphaBetaNumber;
 
             alphaBetaNumber = tr("[Stable]");
@@ -1188,8 +1187,6 @@ void Creator::downloadButtonClicked()
         msgBox.setInformativeText(tr("Do you want to overwrite?"));
         msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
         msgBox.setDefaultButton(QMessageBox::No);
-        msgBox.setButtonText(QMessageBox::Yes, tr("Yes"));
-        msgBox.setButtonText(QMessageBox::No, tr("No"));
         int ret = msgBox.exec();
         if (ret != QMessageBox::Yes) {
             downloadProgressBarText(tr("File already exists."));
@@ -1325,8 +1322,6 @@ void Creator::writeFlashButtonClicked()
                       "Your USB-SD device will be wiped!").arg(destination));
     msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
     msgBox.setDefaultButton(QMessageBox::No);
-    msgBox.setButtonText(QMessageBox::Yes, tr("Yes"));
-    msgBox.setButtonText(QMessageBox::No, tr("No"));
     int ret = msgBox.exec();
     if (ret != QMessageBox::Yes) {
         reset();

--- a/creator.h
+++ b/creator.h
@@ -26,7 +26,7 @@
 #include <QSettings>
 #include <QFile>
 #include <QStandardPaths>
-#include <QTime>
+#include <QElapsedTimer>
 
 #include "downloadmanager.h"
 #include "jsonparser.h"
@@ -125,7 +125,7 @@ private:
     static const QString helpUrl;
     JsonParser *parserData;
     QSettings settings;
-    QTime speedTime;
+    QElapsedTimer speedTime;
     qlonglong bytesLast;
     MovingAverage *averageSpeed;
     unsigned int uncompressedImageSize;

--- a/diskwriter_unix.cpp
+++ b/diskwriter_unix.cpp
@@ -49,7 +49,7 @@ bool DiskWriter_unix::open(const QString& device)
 
     // unmount the device
     QProcess unmount;
-    unmount.start("diskutil unmountDisk "+rawdev, QIODevice::ReadOnly);
+    unmount.start("diskutil", {"unmountDisk", rawdev}, QIODevice::ReadOnly);
     unmount.waitForStarted();
     unmount.waitForFinished();
     dev.setFileName(rawdev);

--- a/jsonparser.cpp
+++ b/jsonparser.cpp
@@ -25,6 +25,7 @@
 #include <QJsonValue>
 #include <QStandardPaths>
 #include <QCollator>
+#include <QRegularExpression>
 #include <QVersionNumber>
 #include <algorithm>
 
@@ -33,11 +34,11 @@ bool compareVersion(const QVariantMap &imageMap1, const QVariantMap &imageMap2)
     // must compare only version not whole string
     // name-8.0.2.img.gz < name-8.0.2.1.img.gz
     // LibreELEC-WeTek_Hub.aarch64-8.0.2.1.img.gz
-    QRegExp regExp = QRegExp(".*-([0-9]+.*)\\.img\\.gz");
-    regExp.indexIn(imageMap1["name"].toString());
-    QStringList versionStr1 = regExp.capturedTexts();
-    regExp.indexIn(imageMap2["name"].toString());
-    QStringList versionStr2 = regExp.capturedTexts();
+    QRegularExpression regExp = QRegularExpression(".*-([0-9]+.*)\\.img\\.gz");
+    QRegularExpressionMatch match = regExp.match(imageMap1["name"].toString());
+    QStringList versionStr1 = match.capturedTexts();
+    QRegularExpressionMatch match2 = regExp.match(imageMap2["name"].toString());
+    QStringList versionStr2 = match2.capturedTexts();
 
     if (versionStr1.count() != 2 || versionStr2.count() != 2)
         return false;   // some error

--- a/linux_build.sh
+++ b/linux_build.sh
@@ -22,13 +22,13 @@ set -e
 echo ""
 if [ "$1" = "32" ]; then
   echo "Building 32 bit version..."
-  QT_DIR=~/Qt5.6.1/5.6-static-32
+  QT_DIR=~/Qt6.2.2/6.2-static-32
 else
   echo "Building 64 bit version..."
-  QT_DIR=~/Qt5.6.1/5.6-static-64
+  QT_DIR=~/Qt6.2.2/6.2-static-64
 fi
 
-export PATH=$QT_DIR/bin:$QT_DIR/../5.6/gcc_64/bin:$PATH
+export PATH=$QT_DIR/bin:$QT_DIR/../6.2.2/gcc_64/bin:$PATH
 
 echo ""
 echo "Creating .qm files"

--- a/main.cpp
+++ b/main.cpp
@@ -60,7 +60,6 @@ void noMessageOutput(QtMsgType type, const QMessageLogContext &context, const QS
 
 int main(int argc, char *argv[])
 {
-    QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
     QApplication app(argc, argv);
     QString argFile = "";
 

--- a/movingaverage.cpp
+++ b/movingaverage.cpp
@@ -21,7 +21,7 @@
 // idea from http://www.codeproject.com/Articles/17860/A-Simple-Moving-Average-Algorithm
 
 // initialize the sample size to the specified number
-MovingAverage::MovingAverage(const uint numSamples)
+MovingAverage::MovingAverage(const unsigned int numSamples)
 {
     size = numSamples;
     total = 0;
@@ -30,20 +30,21 @@ MovingAverage::MovingAverage(const uint numSamples)
 // add sample to a list
 void MovingAverage::AddValue(double val)
 {
-    if (samples.count() == size) {
+    if (samples.size() == size) {
         // substract the oldest value and remove it from the list
-        total -= samples.takeFirst();
+        total -= samples.front();
+        samples.pop_front();
     }
 
-    samples.append(val);  // add new value to the list
+    samples.emplace_back(val);  // add new value to the list
     total += val;
 }
 
 // get the average value
 double MovingAverage::AverageValue()
 {
-    //if (samples.count() < size / 10)
+    //if (samples.size() < size / 10)
     //    return std::numeric_limits<double>::max();
 
-    return total / samples.count();
+    return total / samples.size();
 }

--- a/movingaverage.h
+++ b/movingaverage.h
@@ -19,19 +19,19 @@
 #ifndef MOVINGAVERAGE_H
 #define MOVINGAVERAGE_H
 
-#include <QLinkedList>
+#include <list>
 #include <limits>
 
 class MovingAverage
 {
 public:
-    MovingAverage(const uint numSamples = 10);
+    MovingAverage(const unsigned int numSamples = 10);
     void AddValue(double val);
     double AverageValue();
 
 private:
-    QLinkedList<double> samples;
-    int size;
+    std::list<double> samples;
+    unsigned int size;
     double total;
 };
 

--- a/osx_build.sh
+++ b/osx_build.sh
@@ -23,7 +23,7 @@ echo ""
 echo "Start building..."
 
 USER=$(whoami)
-QBIN="/Users/$USER/Qt/5.15.2-static/bin"
+QBIN="/Users/$USER/Qt/6.2.2-static/bin"
 
 chmod -R 755 dmg_osx
 

--- a/osx_make_dmg.sh
+++ b/osx_make_dmg.sh
@@ -22,7 +22,7 @@ set -e
 DEVICE=""
 
 USER=$(whoami)
-QBIN="/Users/$USER/Qt/5.15.2-static/bin"
+QBIN="/Users/$USER/Qt/6.2.2-static/bin"
 
 function finish {
   echo "Cleaning up..."

--- a/translator.cpp
+++ b/translator.cpp
@@ -23,6 +23,7 @@
 #include <QFile>
 #include <QDir>
 #include <QCollator>
+#include <QRegularExpression>
 #include <algorithm>
 
 Translator::Translator(QObject *parent, QSettings *set) :
@@ -51,9 +52,9 @@ void Translator::fillLanguages(QMenu *menuPtr, QPushButton *langBtnPtr)
     // add menu entry for all the files
     QList<QAction *> actions;
     foreach (const QString &qmFile, qmFiles) {
-        QRegExp regExp = QRegExp("lang-(.*)\\.qm");
-        regExp.indexIn(qmFile);
-        QString locale = regExp.capturedTexts().at(1);
+        QRegularExpression regExp = QRegularExpression("lang-(.*)\\.qm");
+        QRegularExpressionMatch match = regExp.match(qmFile);
+        QString locale = match.captured(1);
 
         QIcon icon;
         QString iconName = "flag-" + locale + ".png";
@@ -134,12 +135,13 @@ void Translator::languageAction(QAction *action)
     if (qtranslator->isFilled())
         qApp->removeTranslator(qtranslator);
 
+    bool loaded = false;
     if (QFile::exists(":/lang/lang-" + locale + ".qm"))
-        qtranslator->load(":/lang/lang-" + locale + ".qm");
+        loaded = qtranslator->load(":/lang/lang-" + locale + ".qm");
     else
-        qtranslator->load("lang-" + locale + ".qm");
+        loaded = qtranslator->load("lang-" + locale + ".qm");
 
-    if (qtranslator->isFilled())
+    if (loaded && qtranslator->isFilled())
         qApp->installTranslator(qtranslator);
 
     // clear checked status

--- a/windows_build.bat
+++ b/windows_build.bat
@@ -17,8 +17,8 @@ rem #  You should have received a copy of the GNU General Public License
 rem #  along with LibreELEC.  If not, see <http://www.gnu.org/licenses/>.
 rem ################################################################################
 
-set PATH=c:\Qt\Qt5.6.1-static\bin;%PATH%
-set PATH=c:\Qt\Qt5.6.1\Tools\mingw492_32\bin;%PATH%
+set PATH=c:\Qt\Qt6.2.2-static\bin;%PATH%
+set PATH=c:\Qt\Qt6.2.2\Tools\mingw492_32\bin;%PATH%
 
 del release\LibreELEC.USB-SD.Creator.Win32.exe > nul 2>&1
 

--- a/windows_clean.bat
+++ b/windows_clean.bat
@@ -17,8 +17,8 @@ rem #  You should have received a copy of the GNU General Public License
 rem #  along with LibreELEC.  If not, see <http://www.gnu.org/licenses/>.
 rem ################################################################################
 
-set PATH=c:\Qt\Qt5.6.1-static\bin;%PATH%
-set PATH=c:\Qt\Qt5.6.1\Tools\mingw492_32\bin;%PATH%
+set PATH=c:\Qt\Qt6.2.2-static\bin;%PATH%
+set PATH=c:\Qt\Qt6.2.2\Tools\mingw492_32\bin;%PATH%
 
 if exist Makefile (
   mingw32-make distclean


### PR DESCRIPTION
Should fix the build errors on mac with the resources and make the required changes to build with QT 6.2.2

I built QT on mac like this:

```
mkdir -p ~/Downloads ~/Qt
cd ~/Downloads
wget https://download.qt.io/official_releases/qt/6.2/6.2.2/single/qt-everywhere-src-6.2.2.tar.xz
tar xf qt-everywhere-src-6.2.2.tar.xz
cd qt-everywhere-src-6.2.2
./configure -static -no-shared -release -opensource -confirm-license -silent -prefix ~/Qt/6.2.2-static -nomake examples -nomake tests -no-strip -no-cups -qt-zlib -qt-pcre -qt-libpng -qt-libjpeg -qt-harfbuzz -qt-freetype
ninja qtbase/all qttools/all
ninja install
```

For windows builds use configure.bat instead with similar options and add the pre-setup from here: https://doc.qt.io/qt-6/windows-building.html