### PR TITLE
Uboot list

### DIFF
--- a/creator.cpp
+++ b/creator.cpp
@@ -251,6 +251,7 @@ Creator::~Creator()
     diskWriterThread->wait();
     delete diskWriterThread;
     delete devEnumerator;
+    delete parserData;
 }
 
 void Creator::httpsUrlHandler(const QUrl &url)

--- a/creator.cpp
+++ b/creator.cpp
@@ -491,11 +491,11 @@ void Creator::parseJsonAndSet(const QByteArray &data)
 
     ui->projectSelectBox->clear();
 
-    QList<JsonData> dataList = parserData->getJsonData();
-    for (int ix = 0; ix < dataList.size(); ix++) {
-        QString projectName = dataList.at(ix).name;
-        QString projectId = dataList.at(ix).id;
-        QString projectUrl = dataList.at(ix).url;
+    QList<ProjectData> dataList = parserData->getProjectData();
+    for (auto& project : dataList) {
+        QString projectName = project.name;
+        QString projectId = project.id;
+        QString projectUrl = project.url;
 
         QVariantMap projectData;
         projectData.insert("id", projectId);
@@ -537,15 +537,15 @@ void Creator::setProjectImages()
 
     ui->imageSelectBox->clear();
 
-    QList<JsonData> dataList = parserData->getJsonData();
-    for (int ix = 0; ix < dataList.size(); ix++) {
-        QString projectName = dataList.at(ix).name;
+    QList<ProjectData> dataList = parserData->getProjectData();
+    for (auto& project : dataList) {
+        QString projectName = project.name;
 
         // show images only for selected project
         if (projectName != ui->projectSelectBox->currentText())
             continue;
 
-        QList<QVariantMap> releases = dataList.at(ix).images;
+        QList<QVariantMap> releases = project.images;
         for (QList<QVariantMap>::const_iterator it = releases.constBegin();
              it != releases.constEnd();
              it++)
@@ -565,7 +565,8 @@ void Creator::setProjectImages()
                 imageSize = QString::number(size) + " MB";
             }
 
-            //  LibreELEC-RPi2.arm-7.90.002.img.gz
+            // LibreELEC-RPi2.arm-7.90.002.img.gz
+            // LibreELEC-TinkerBoard.arm-8.90.015-rk3288.img.gz
             QRegularExpression regExp = QRegularExpression(".+-[0-9]+\\.(9[05])\\.[0-9]+.*\\.img\\.gz");
             QRegularExpressionMatch match = regExp.match(imageName);
             QStringList regExpVal = match.capturedTexts();

--- a/creator.cpp
+++ b/creator.cpp
@@ -491,8 +491,8 @@ void Creator::parseJsonAndSet(const QByteArray &data)
 
     ui->projectSelectBox->clear();
 
-    QList<ProjectData> dataList = parserData->getProjectData();
-    for (auto& project : dataList) {
+    QList<ProjectData> projectList = parserData->getProjectData();
+    for (auto& project : projectList) {
         QString projectName = project.name;
         QString projectId = project.id;
         QString projectUrl = project.url;
@@ -537,8 +537,8 @@ void Creator::setProjectImages()
 
     ui->imageSelectBox->clear();
 
-    QList<ProjectData> dataList = parserData->getProjectData();
-    for (auto& project : dataList) {
+    QList<ProjectData> projectList = parserData->getProjectData();
+    for (auto& project : projectList) {
         QString projectName = project.name;
 
         // show images only for selected project

--- a/dmg_osx/template.app/Contents/Info.plist
+++ b/dmg_osx/template.app/Contents/Info.plist
@@ -42,5 +42,7 @@
 		<key>selectedTabView</key>
 		<string>result</string>
 	</dict>
+	<key>NSRequiresAquaSystemAppearance</key>
+	<true/>
 </dict>
 </plist>

--- a/downloadmanager.cpp
+++ b/downloadmanager.cpp
@@ -77,6 +77,10 @@ void DownloadManager::handleGetFinished(QNetworkReply *reply)
         switch (responseCode) {
         case RESPONSE_FOUND:
             redirectionUrl = reply->header(QNetworkRequest::LocationHeader).toUrl();
+            // Fallthrough to redirect is required, hence no break;
+#if (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L) || (defined(__cplusplus) && __cplusplus >= 201703L)
+            [[fallthrough]];
+#endif
         case RESPONSE_REDIRECT:
             if (redirectionUrl.isValid()) {
                 qDebug() << reply->url() << "redirected to" << redirectionUrl;

--- a/jsonparser.h
+++ b/jsonparser.h
@@ -25,25 +25,25 @@
 #include <QVariant>
 #include <QDebug>
 
-class JsonData
+class ProjectData
 {
   public:
-    JsonData() {}
+    ProjectData() {}
 
-    JsonData(QString name, QString id, QString url, QList<QMap<QString, QVariant>> &images)
+    ProjectData(QString name, QString id, QString url, QList<QMap<QString, QVariant>> &images)
     {
          addData(name, id, url, images);
     }
 
     void addData(QString name, QString id, QString url, QList<QMap<QString, QVariant>> &images)
     {
-        JsonData::name = name;
-        JsonData::id = id;
-        JsonData::url = url;
-        JsonData::images = images;
+        ProjectData::name = name;
+        ProjectData::id = id;
+        ProjectData::url = url;
+        ProjectData::images = images;
     }
 
-    bool operator== (const JsonData &data) const
+    bool operator== (const ProjectData &data) const
     {
         if (data.name == this->name)
             return true;
@@ -64,10 +64,10 @@ public:
     JsonParser(const QByteArray &data);
     void addExtra(const QByteArray &data, const QString label);
     void parseAndSet(const QByteArray &data, const QString label);
-    QList<JsonData> getJsonData() const;
+    QList<ProjectData> getProjectData() const;
 
 private:
-    QList<JsonData> dataList;
+    QList<ProjectData> dataList;
 };
 
 #endif // JSONPARSER_H

--- a/jsonparser.h
+++ b/jsonparser.h
@@ -67,7 +67,7 @@ public:
     QList<ProjectData> getProjectData() const;
 
 private:
-    QList<ProjectData> dataList;
+    QList<ProjectData> projectList;
 };
 
 #endif // JSONPARSER_H


### PR DESCRIPTION
Every time I tried to sort the images this will crash if the uboot list of images is added per project.

 I moved from QT lists of references to std:vectors of shared_ptrs and it still crashes. So the pointers are getting messed up somewhere. The version here just adds uboot support and changes range based for loop operators where possible.

@kambala, maybe you can take a look and possibly figure out what the issue is. It will likely be something obvious.