### PR TITLE
Use template Info.plist for development instead of QT default

### DIFF
--- a/creator.pro
+++ b/creator.pro
@@ -151,6 +151,7 @@ macx {
     # Specifies where to find the libraries at runtime
     QMAKE_RPATHDIR += @executable_path/../Frameworks
     QMAKE_LFLAGS_SONAME = -Wl,-install_name,@rpath/
+    QMAKE_INFO_PLIST = dmg_osx/template.app/Contents/Info.plist
     #QT_CONFIG -= no-pkg-config
     #CONFIG += link_pkgconfig
     # same thing


### PR DESCRIPTION
Small change for Mac so that the disabling of dark mode is picked up while developing. Otherwise it's really hard on the eyes.